### PR TITLE
fix: correct binary naming in vb upgrade command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.1.3] - 2025-10-02
+
+### Fixed
+
+- Fixed `vb upgrade` command binary naming discrepancy - now correctly matches GitHub Actions release asset names (e.g., `vb-macos-arm64` instead of `vb_darwin_arm64`)
+
 ## [v0.1.2] - 2025-01-27
 
 ### Added

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -76,11 +76,18 @@ func (u *Upgrader) GetBinaryName() string {
 		arch = "amd64" // fallback
 	}
 
-	// Map Go OS names to common release naming conventions
+	// Map Go OS names to GitHub Actions release naming conventions
+	// This matches the platform names used in .github/workflows/release.yml and auto-release.yml
 	switch os {
+	case "darwin":
+		// macOS uses "macos" in the release asset names
+		return fmt.Sprintf("vb-macos-%s", arch)
+	case "linux":
+		return fmt.Sprintf("vb-linux-%s", arch)
 	case "windows":
-		return fmt.Sprintf("vb_%s_%s.exe", os, arch)
+		return fmt.Sprintf("vb-windows-%s.exe", arch)
 	default:
+		// Fallback to the old format for unknown OS
 		return fmt.Sprintf("vb_%s_%s", os, arch)
 	}
 }

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -42,10 +42,18 @@ func TestGetBinaryName(t *testing.T) {
 		expectedArch = "amd64"
 	}
 
+	// Map Go OS names to GitHub Actions release naming conventions
 	var expectedName string
-	if expectedOS == "windows" {
-		expectedName = fmt.Sprintf("vb_%s_%s.exe", expectedOS, expectedArch)
-	} else {
+	switch expectedOS {
+	case "darwin":
+		// macOS uses "macos" in the release asset names
+		expectedName = fmt.Sprintf("vb-macos-%s", expectedArch)
+	case "linux":
+		expectedName = fmt.Sprintf("vb-linux-%s", expectedArch)
+	case "windows":
+		expectedName = fmt.Sprintf("vb-windows-%s.exe", expectedArch)
+	default:
+		// Fallback to the old format for unknown OS
 		expectedName = fmt.Sprintf("vb_%s_%s", expectedOS, expectedArch)
 	}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Current defines the CLI semantic version following https://semver.org/.
-const Current = "v0.1.2"
+const Current = "v0.1.3"


### PR DESCRIPTION
- Update GetBinaryName() to use vb-{platform} format matching GitHub Actions releases
- Fix discrepancy between upgrade command and release asset names
- Update tests to reflect new naming convention
- Bump version to v0.1.3

Fixes issue where vb upgrade failed with 'binary vb_darwin_arm64 not found' Now correctly looks for vb-macos-arm64, vb-linux-amd64, etc.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Test coverage remains at 100%
- [ ] Manual testing completed

## Security

- [ ] Security scan passes (`make scan`)
- [ ] No new security vulnerabilities introduced
- [ ] File permissions are appropriate
- [ ] No hardcoded secrets or credentials

## Documentation

- [ ] README.md updated (if needed)
- [ ] CLI.md updated (if command behavior changed)
- [ ] DEVELOPMENT.md updated (if build process changed)
- [ ] CHANGELOG.md updated
- [ ] Code comments added for complex logic

## Version Bump

- [ ] Version bumped in `internal/version/version.go`
- [ ] Changelog entry added
- [ ] Version bump type: [ ] Major [ ] Minor [ ] Patch

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Code is properly commented
- [ ] No debug code or console logs left
- [ ] All `make` targets pass locally
- [ ] Pre-commit hooks pass

## Additional Notes

Any additional information, context, or screenshots that would help reviewers understand the changes.
