### PR TITLE
Bump version to v0.8.2 and ignore audit.jsonl in template updates

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -435,7 +435,7 @@ jobs:
 
       - name: Create Release
         id: create-release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         continue-on-error: true
         with:
           tag_name: ${{ needs.determine-release.outputs.tag-name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,7 +216,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.changelog.outputs.version }}
           name: Release ${{ steps.changelog.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+## [v0.8.2] - 2026-04-28
+
+### Fixed
+
+- `vb init --update` now ignores `.virtualboard/audit.jsonl`, since the local append-only audit log will always diverge from the template
+
 ## [v0.8.1] - 2026-04-12
 
 ### Changed

--- a/internal/templatediff/differ.go
+++ b/internal/templatediff/differ.go
@@ -232,6 +232,10 @@ func shouldSkipFile(relPath string) bool {
 	if relPath == "features/INDEX.md" || relPath == filepath.Join("features", "INDEX.md") {
 		return true
 	}
+	// Skip audit.jsonl - local append-only audit log, always diverges from template
+	if relPath == "audit.jsonl" {
+		return true
+	}
 	return false
 }
 

--- a/internal/templatediff/differ_test.go
+++ b/internal/templatediff/differ_test.go
@@ -323,6 +323,16 @@ func TestShouldSkipFile(t *testing.T) {
 			path: "templates/feature.md",
 			want: false,
 		},
+		{
+			name: "audit.jsonl should be skipped",
+			path: "audit.jsonl",
+			want: true,
+		},
+		{
+			name: "audit.jsonl in subdirectory should not be skipped",
+			path: "features/audit.jsonl",
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Current defines the CLI semantic version following https://semver.org/.
-const Current = "v0.8.1"
+const Current = "v0.8.2"
 
 // Parsed represents a parsed semantic version.
 type Parsed struct {


### PR DESCRIPTION
`vb init --update` skips `.virtualboard/audit.jsonl` since the local append-only audit log will always diverge from the upstream template.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Test coverage remains at 100%
- [ ] Manual testing completed

## Security

- [ ] Security scan passes (`make scan`)
- [ ] No new security vulnerabilities introduced
- [ ] File permissions are appropriate
- [ ] No hardcoded secrets or credentials

## Documentation

- [ ] README.md updated (if needed)
- [ ] CLI.md updated (if command behavior changed)
- [ ] DEVELOPMENT.md updated (if build process changed)
- [ ] CHANGELOG.md updated
- [ ] Code comments added for complex logic

## Version Bump

- [ ] Version bumped in `internal/version/version.go`
- [ ] Changelog entry added
- [ ] Version bump type: [ ] Major [ ] Minor [ ] Patch

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Code is properly commented
- [ ] No debug code or console logs left
- [ ] All `make` targets pass locally
- [ ] Pre-commit hooks pass

## Additional Notes

Any additional information, context, or screenshots that would help reviewers understand the changes.
