### PR TITLE
Add vb audit command and bump version to v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [v0.9.0] - 2026-05-17
 
+### Changed
+
+- Bump `golang.org/x/term` from 0.42.0 to 0.43.0 (transitive `golang.org/x/sys` 0.43.0 → 0.44.0); incorporates [#51](https://github.com/virtualboard/vb-cli/pull/51)
+
 ### Added
 
 - `vb audit` command for inspecting the SHA-256 hash-chained audit log at `.virtualboard/audit.jsonl`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+## [v0.9.0] - 2026-05-17
+
+### Added
+
+- `vb audit` command for inspecting the SHA-256 hash-chained audit log at `.virtualboard/audit.jsonl`
+- Audit filters: `--action`, `--actor`, `--feature-id` (all repeatable, OR-within / AND-across), `--since` / `--until` (RFC3339 or YYYY-MM-DD), `--contains` (case-insensitive substring match on details), `--limit`, `--tail`
+- Six audit output formats via `--format`: `human` (default), `table`, `jsonl`, `json`, `xml`, `agent` (LLM-friendly key:value blocks)
+- `--verify` flag walks the hash chain and exits with `ExitCodeValidation` (1) on any tampering
+- `internal/audit` package gains `Read`, `Filter`/`Apply`, `Verify`, `Render`, `ParseFormat`, and `ParseTime` exports so other tools can consume the audit log programmatically
+
 ## [v0.8.2] - 2026-04-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tests](https://img.shields.io/badge/tests-passing-brightgreen.svg)](docs/DEVELOPMENT.md#development)
 [![Coverage](https://img.shields.io/badge/coverage-100%25-blue.svg)](docs/DEVELOPMENT.md#development)
-[![Release](https://img.shields.io/badge/version-v0.7.0-informational.svg)](CHANGELOG.md)
+[![Release](https://img.shields.io/badge/version-v0.9.0-informational.svg)](CHANGELOG.md)
 [![Semantic Versioning](https://img.shields.io/badge/semver-2.0.0-blue.svg)](https://semver.org/spec/v2.0.0.html)
 
 VirtualBoard CLI (`vb`) is the workspace companion for authoring, validating, and shipping feature specifications that live under `.virtualboard/`. It keeps teams in sync by scaffolding new specs, guarding workflow transitions, surfacing validation issues early, and generating stakeholder-friendly indexes.
@@ -13,6 +13,7 @@ VirtualBoard CLI (`vb`) is the workspace companion for authoring, validating, an
 - Install IDE integrations with `vb install <ide>` for Claude Code, Cursor, and OpenCode.
 - Create, update, move, delete, and lock features end-to-end via dedicated subcommands (`vb new`, `vb update`, `vb move`, `vb delete`, `vb lock`).
 - Validate both feature specs and system specs with `vb validate`, supporting schema validation for features (workflow, dependencies) and specs (architectural blueprints). Use `--only-features` or `--only-specs` to validate specific types.
+- Inspect the tamper-evident audit log with `vb audit`, supporting filters on every column (action, actor, feature_id, time range, details substring), six output formats (human, table, jsonl, json, xml, agent), and `--verify` to walk the SHA-256 hash chain.
 - Regenerate indices in Markdown/JSON/HTML with `vb index`.
 - Apply opinionated templates and fixes (`vb template apply`) while maintaining 100% unit-test coverage and gosec-scanned code.
 - Self-update to the latest version with `vb upgrade`, which automatically detects your platform and downloads the appropriate binary from GitHub releases.
@@ -83,6 +84,9 @@ vb validate                  # validate both features and system specs
 vb validate --only-features  # validate only feature specs
 vb validate --only-specs     # validate only system specs
 vb index                     # emit .virtualboard/features/INDEX.md
+vb audit                     # browse the hash-chained audit log
+vb audit --format table --actor netors --since 2026-04-01
+vb audit --verify            # check the audit chain for tampering
 vb upgrade                   # check for and install the latest version
 ```
 

--- a/cmd/audit.go
+++ b/cmd/audit.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/virtualboard/vb-cli/internal/audit"
+)
+
+func newAuditCommand() *cobra.Command {
+	var (
+		actions    []string
+		actors     []string
+		featureIDs []string
+		since      string
+		until      string
+		contains   string
+		limit      int
+		tail       bool
+		format     string
+		verify     bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "audit",
+		Short: "Inspect the hash-chained audit log",
+		Long: `Read and filter .virtualboard/audit.jsonl.
+
+The audit log is the append-only, SHA-256-chained record of every locking and
+feature-mutation action. Use this command to query it without resorting to
+jq / grep, and to optionally verify the integrity of the hash chain.
+
+Examples:
+  vb audit                                              # default human format
+  vb audit --format table
+  vb audit --format jsonl --action lock --action unlock
+  vb audit --format json --actor netors --since 2026-04-16
+  vb audit --format agent --feature-id FTR-0019
+  vb audit --contains "ttl=1" --limit 5 --tail
+  vb audit --verify                                     # exit 1 on tampering`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts, err := options()
+			if err != nil {
+				return err
+			}
+
+			sinceTime, err := audit.ParseTime(since)
+			if err != nil {
+				return WrapCLIError(ExitCodeValidation, fmt.Errorf("--since: %w", err))
+			}
+			untilTime, err := audit.ParseTime(until)
+			if err != nil {
+				return WrapCLIError(ExitCodeValidation, fmt.Errorf("--until: %w", err))
+			}
+
+			fmtKind, err := audit.ParseFormat(format)
+			if err != nil {
+				return WrapCLIError(ExitCodeValidation, err)
+			}
+
+			path := filepath.Join(opts.RootDir, "audit.jsonl")
+			entries, parseErrs, err := audit.Read(path)
+			if err != nil {
+				return WrapCLIError(ExitCodeFilesystem, err)
+			}
+			if opts.Verbose && len(parseErrs) > 0 {
+				log := opts.Logger().WithField("component", "audit")
+				for _, perr := range parseErrs {
+					log.Warnf("skipped malformed audit entry: %v", perr)
+				}
+			}
+
+			filtered := audit.Filter{
+				Actions:    actions,
+				Actors:     actors,
+				FeatureIDs: featureIDs,
+				Since:      sinceTime,
+				Until:      untilTime,
+				Contains:   contains,
+				Limit:      limit,
+				Tail:       tail,
+			}.Apply(entries)
+
+			if verify {
+				if verr := audit.Verify(entries); verr != nil {
+					return WrapCLIError(ExitCodeValidation, fmt.Errorf("audit chain verification failed: %w", verr))
+				}
+			}
+
+			if opts.JSONOutput {
+				data := map[string]interface{}{
+					"path":         relOrAbs(opts.RootDir, path),
+					"total":        len(entries),
+					"count":        len(filtered),
+					"entries":      filtered,
+					"verified":     verify,
+					"parse_errors": len(parseErrs),
+				}
+				return respond(cmd, opts, true, "audit entries returned", data)
+			}
+
+			content, err := audit.Render(filtered, fmtKind, audit.RenderOptions{IncludeHashes: opts.Verbose})
+			if err != nil {
+				return WrapCLIError(ExitCodeValidation, err)
+			}
+			fmt.Fprint(cmd.OutOrStdout(), content)
+			if verify {
+				fmt.Fprintln(cmd.OutOrStdout(), "Audit chain verified: OK")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&actions, "action", nil, "Filter by action (repeatable; OR within flag)")
+	cmd.Flags().StringSliceVar(&actors, "actor", nil, "Filter by actor (repeatable; OR within flag)")
+	cmd.Flags().StringSliceVar(&featureIDs, "feature-id", nil, "Filter by feature_id (repeatable; OR within flag)")
+	cmd.Flags().StringVar(&since, "since", "", "Lower-bound timestamp (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&until, "until", "", "Upper-bound timestamp (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&contains, "contains", "", "Case-insensitive substring match on details")
+	cmd.Flags().IntVar(&limit, "limit", 0, "Cap the number of returned entries (0 = no cap)")
+	cmd.Flags().BoolVar(&tail, "tail", false, "With --limit, return the last N entries instead of the first N")
+	cmd.Flags().StringVar(&format, "format", "human", "Output format: human, table, jsonl, json, xml, agent. Ignored when --json is set.")
+	cmd.Flags().BoolVar(&verify, "verify", false, "Walk the hash chain and fail on tampering")
+
+	return cmd
+}
+
+// relOrAbs returns the path relative to root if possible, otherwise the absolute path.
+// Falling back to the absolute path keeps JSON consumers safe when the audit
+// file lives outside the workspace (e.g. a symlinked or remote-mounted log).
+func relOrAbs(root, path string) string {
+	if rel, err := filepath.Rel(root, path); err == nil {
+		return rel
+	}
+	return path
+}

--- a/cmd/audit_test.go
+++ b/cmd/audit_test.go
@@ -1,0 +1,306 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/virtualboard/vb-cli/internal/audit"
+	"github.com/virtualboard/vb-cli/internal/config"
+	"github.com/virtualboard/vb-cli/internal/testutil"
+)
+
+// writeAuditLog seeds .virtualboard/audit.jsonl with a hash-chained set of entries.
+func writeAuditLog(t *testing.T, fix *testutil.Fixture) string {
+	t.Helper()
+	workspace := filepath.Join(fix.Root, ".virtualboard")
+	path := filepath.Join(workspace, "audit.jsonl")
+	logger, err := audit.NewLogger(path)
+	if err != nil {
+		t.Fatalf("NewLogger failed: %v", err)
+	}
+	seed := []struct {
+		action, actor, fid, details string
+	}{
+		{"create", "alice", "FTR-1", "first feature"},
+		{"lock", "alice", "FTR-1", "owner=alice ttl=1"},
+		{"unlock", "alice", "FTR-1", "owner=alice"},
+		{"move", "bob", "FTR-1", "from=backlog to=in-progress"},
+		{"create", "carol", "FTR-2", ""},
+	}
+	for _, e := range seed {
+		if err := logger.Log(e.action, e.actor, e.fid, e.details); err != nil {
+			t.Fatalf("Log failed: %v", err)
+		}
+	}
+	return path
+}
+
+func runAudit(t *testing.T, fix *testutil.Fixture, opts *config.Options, args ...string) string {
+	t.Helper()
+	config.SetCurrent(opts)
+	cmd := newAuditCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("audit %v failed: %v\noutput:\n%s", args, err, buf.String())
+	}
+	return buf.String()
+}
+
+func TestAuditCommandHumanDefault(t *testing.T) {
+	fix := testutil.NewFixture(t)
+	writeAuditLog(t, fix)
+	opts, _ := setupOptions(t, fix, false, false, false)
+	out := runAudit(t, fix, opts)
+	// All five seeded actions should appear in default human output.
+	for _, action := range []string{"create", "lock", "unlock", "move"} {
+		if !strings.Contains(out, action) {
+			t.Fatalf("expected %q in human output, got:\n%s", action, out)
+		}
+	}
+	// Hashes should be hidden by default.
+	if strings.Contains(out, "prev=") {
+		t.Fatalf("default human output should not include hashes:\n%s", out)
+	}
+}
+
+func TestAuditCommandTableAndAgentAndXML(t *testing.T) {
+	fix := testutil.NewFixture(t)
+	writeAuditLog(t, fix)
+	opts, _ := setupOptions(t, fix, false, false, false)
+
+	tableOut := runAudit(t, fix, opts, "--format", "table")
+	if !strings.Contains(tableOut, "TIMESTAMP") {
+		t.Fatalf("table missing header:\n%s", tableOut)
+	}
+
+	agentOut := runAudit(t, fix, opts, "--format", "agent")
+	if !strings.Contains(agentOut, "count: 5") || !strings.Contains(agentOut, "--- entry 1 ---") {
+		t.Fatalf("agent output wrong:\n%s", agentOut)
+	}
+
+	xmlOut := runAudit(t, fix, opts, "--format", "xml")
+	if !strings.Contains(xmlOut, "<audit") || !strings.Contains(xmlOut, "<entry>") {
+		t.Fatalf("xml output wrong:\n%s", xmlOut)
+	}
+
+	jsonlOut := runAudit(t, fix, opts, "--format", "jsonl")
+	if strings.Count(jsonlOut, "\n") != 5 {
+		t.Fatalf("expected 5 jsonl lines, got:\n%s", jsonlOut)
+	}
+}
+
+func TestAuditCommandFilters(t *testing.T) {
+	fix := testutil.NewFixture(t)
+	writeAuditLog(t, fix)
+	opts, _ := setupOptions(t, fix, false, false, false)
+
+	// --action lock should yield exactly one row.
+	out := runAudit(t, fix, opts, "--format", "jsonl", "--action", "lock")
+	if strings.Count(strings.TrimRight(out, "\n"), "\n")+1 != 1 {
+		t.Fatalf("expected 1 lock entry, got:\n%s", out)
+	}
+	if !strings.Contains(out, "\"action\":\"lock\"") {
+		t.Fatalf("expected lock entry in output:\n%s", out)
+	}
+
+	// --actor alice: 3 entries.
+	out = runAudit(t, fix, opts, "--format", "jsonl", "--actor", "alice")
+	if got := strings.Count(strings.TrimRight(out, "\n"), "\n") + 1; got != 3 {
+		t.Fatalf("expected 3 alice entries, got %d:\n%s", got, out)
+	}
+
+	// --feature-id FTR-2: 1 entry.
+	out = runAudit(t, fix, opts, "--format", "jsonl", "--feature-id", "FTR-2")
+	if got := strings.Count(strings.TrimRight(out, "\n"), "\n") + 1; got != 1 {
+		t.Fatalf("expected 1 FTR-2 entry, got %d:\n%s", got, out)
+	}
+
+	// --contains "ttl" matches the lock entry only.
+	out = runAudit(t, fix, opts, "--format", "jsonl", "--contains", "TTL")
+	if got := strings.Count(strings.TrimRight(out, "\n"), "\n") + 1; got != 1 {
+		t.Fatalf("expected 1 contains-match, got %d:\n%s", got, out)
+	}
+
+	// --limit 2 yields first two entries.
+	out = runAudit(t, fix, opts, "--format", "jsonl", "--limit", "2")
+	if got := strings.Count(strings.TrimRight(out, "\n"), "\n") + 1; got != 2 {
+		t.Fatalf("expected 2 head entries, got %d:\n%s", got, out)
+	}
+	if !strings.Contains(out, "\"action\":\"create\"") {
+		t.Fatalf("expected first entry to be create:\n%s", out)
+	}
+
+	// --limit 2 --tail yields last two entries.
+	out = runAudit(t, fix, opts, "--format", "jsonl", "--limit", "2", "--tail")
+	if !strings.Contains(out, "\"feature_id\":\"FTR-2\"") {
+		t.Fatalf("expected tail to include last entry:\n%s", out)
+	}
+}
+
+func TestAuditCommandJSONOutput(t *testing.T) {
+	fix := testutil.NewFixture(t)
+	writeAuditLog(t, fix)
+	opts, _ := setupOptions(t, fix, true, false, false)
+	out := runAudit(t, fix, opts, "--format", "table") // --format must be ignored
+	var payload struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Path    string        `json:"path"`
+			Total   int           `json:"total"`
+			Count   int           `json:"count"`
+			Entries []audit.Entry `json:"entries"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("JSON output not parseable: %v\n%s", err, out)
+	}
+	if !payload.Success || payload.Data.Count != 5 || payload.Data.Total != 5 {
+		t.Fatalf("unexpected JSON payload: %+v", payload.Data)
+	}
+}
+
+func TestAuditCommandVerifySuccess(t *testing.T) {
+	fix := testutil.NewFixture(t)
+	writeAuditLog(t, fix)
+	opts, _ := setupOptions(t, fix, false, false, false)
+	out := runAudit(t, fix, opts, "--verify")
+	if !strings.Contains(out, "Audit chain verified: OK") {
+		t.Fatalf("expected verification confirmation, got:\n%s", out)
+	}
+}
+
+func TestAuditCommandVerifyFailure(t *testing.T) {
+	fix := testutil.NewFixture(t)
+	path := writeAuditLog(t, fix)
+
+	// Corrupt the second line's entry_hash to break the chain.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
+	lines[1] = strings.Replace(lines[1], "\"entry_hash\":\"", "\"entry_hash\":\"00", 1)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	opts, _ := setupOptions(t, fix, false, false, false)
+	config.SetCurrent(opts)
+	cmd := newAuditCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--verify"})
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected verify failure to return error")
+	}
+	if ExitCode(err) != ExitCodeValidation {
+		t.Fatalf("expected ExitCodeValidation, got %d", ExitCode(err))
+	}
+}
+
+func TestAuditCommandInvalidFormat(t *testing.T) {
+	fix := testutil.NewFixture(t)
+	writeAuditLog(t, fix)
+	opts, _ := setupOptions(t, fix, false, false, false)
+	config.SetCurrent(opts)
+	cmd := newAuditCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--format", "yaml"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("expected error for unknown format")
+	} else if ExitCode(err) != ExitCodeValidation {
+		t.Fatalf("expected ExitCodeValidation, got %d", ExitCode(err))
+	}
+}
+
+func TestAuditCommandInvalidTimeFlags(t *testing.T) {
+	fix := testutil.NewFixture(t)
+	writeAuditLog(t, fix)
+
+	for _, flag := range []string{"--since", "--until"} {
+		t.Run(flag, func(t *testing.T) {
+			opts, _ := setupOptions(t, fix, false, false, false)
+			config.SetCurrent(opts)
+			cmd := newAuditCommand()
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs([]string{flag, "yesterday"})
+			if err := cmd.Execute(); err == nil {
+				t.Fatalf("expected error for invalid time on %s", flag)
+			} else if ExitCode(err) != ExitCodeValidation {
+				t.Fatalf("expected ExitCodeValidation, got %d", ExitCode(err))
+			}
+		})
+	}
+}
+
+func TestAuditCommandTimeRange(t *testing.T) {
+	fix := testutil.NewFixture(t)
+	writeAuditLog(t, fix)
+	opts, _ := setupOptions(t, fix, false, false, false)
+
+	// Wide window catches everything.
+	out := runAudit(t, fix, opts, "--format", "jsonl", "--since", "1970-01-01", "--until", "2999-01-01")
+	if got := strings.Count(strings.TrimRight(out, "\n"), "\n") + 1; got != 5 {
+		t.Fatalf("expected all 5 entries in wide window, got %d", got)
+	}
+
+	// Window in the distant future filters everything out.
+	out = runAudit(t, fix, opts, "--format", "jsonl", "--since", "2999-01-01")
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("expected empty output for future window, got:\n%s", out)
+	}
+}
+
+func TestAuditCommandMissingFile(t *testing.T) {
+	fix := testutil.NewFixture(t)
+	// No audit log written.
+	opts, _ := setupOptions(t, fix, false, false, false)
+	out := runAudit(t, fix, opts)
+	if !strings.Contains(out, "No audit entries") {
+		t.Fatalf("expected empty-state message, got %q", out)
+	}
+}
+
+func TestAuditCommandVerboseHashes(t *testing.T) {
+	fix := testutil.NewFixture(t)
+	writeAuditLog(t, fix)
+	opts, _ := setupOptions(t, fix, false, true, false)
+	out := runAudit(t, fix, opts, "--format", "human")
+	if !strings.Contains(out, "prev=") || !strings.Contains(out, "hash=") {
+		t.Fatalf("verbose human output should show hashes:\n%s", out)
+	}
+}
+
+func TestAuditCommandVerboseLogsParseErrors(t *testing.T) {
+	fix := testutil.NewFixture(t)
+	path := writeAuditLog(t, fix)
+	// Append a malformed line.
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("not a json line\n"); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	opts, _ := setupOptions(t, fix, false, true, false)
+	out := runAudit(t, fix, opts)
+	// Valid entries still render.
+	if !strings.Contains(out, "create") {
+		t.Fatalf("expected valid entries to still render, got:\n%s", out)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,4 +80,5 @@ func registerCommands() {
 	rootCmd.AddCommand(newInstallCommand())
 	rootCmd.AddCommand(newVersionCommand())
 	rootCmd.AddCommand(newUpgradeCommand())
+	rootCmd.AddCommand(newAuditCommand())
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -250,6 +250,75 @@ Acquire, check, or release feature locks.
 - `--status` – Show lock status
 - `--force` – Override an active lock
 
+### `vb audit`
+
+Inspect the SHA-256 hash-chained audit log at `.virtualboard/audit.jsonl`. The
+log is appended to by every lock/unlock and feature-mutation action; this
+command lets you query it without resorting to `jq`/`grep` and optionally
+verify the integrity of the chain.
+
+**Filter Flags (combine with AND across, OR within a repeated flag):**
+
+- `--action <name>` – Filter by action value (e.g. `lock`, `unlock`, `move`, `create`, `delete`). Repeatable.
+- `--actor <name>` – Filter by actor. Repeatable.
+- `--feature-id <id>` – Filter by feature_id. Repeatable.
+- `--since <time>` – Inclusive lower bound. Accepts `2026-04-16` or `2026-04-16T21:06:59Z`.
+- `--until <time>` – Inclusive upper bound. Same formats.
+- `--contains <substr>` – Case-insensitive substring match against the `details` column.
+- `--limit <n>` – Cap the number of returned entries (0 = no cap).
+- `--tail` – When `--limit` is set, return the LAST n entries instead of the first n.
+
+**Output Flags:**
+
+- `--format <fmt>` – One of: `human` (default), `table`, `jsonl`, `json`, `xml`, `agent`. Ignored when `--json` is set.
+- `--verify` – Walk the hash chain and fail with exit code `1` (Validation) on any tampering. Prints `Audit chain verified: OK` when the chain is intact.
+
+**Formats:**
+
+| Format | Description |
+|--------|-------------|
+| `human` | One line per entry with reformatted timestamps. Hides hashes unless `--verbose`. The default. |
+| `table` | Fixed-width text table via `tabwriter`. With `--verbose`, includes truncated `prev`/`hash` columns. |
+| `jsonl` | Round-trippable: one JSON object per line, identical to the on-disk format. |
+| `json` | Single document `{"count": N, "entries": [...]}` for scripting. |
+| `xml` | `<audit count="N"><entry>...</entry></audit>` for legacy tooling. |
+| `agent` | Compact `key: value` blocks separated by `--- entry N ---` headers, optimised for LLM consumption. Empty optional fields are omitted. |
+
+**Interaction with `--json`:**
+
+When the global `--json` flag is set, the response is always wrapped as
+`{success, message, data:{path, total, count, entries, verified, parse_errors}}`
+and `--format` is ignored. This matches the convention used by other `vb`
+commands: `--json` is for programmatic consumers, `--format` for presentation.
+
+**Examples:**
+
+```bash
+# Default human-readable output
+vb audit
+
+# All lock/unlock activity as a table
+vb audit --format table --action lock --action unlock
+
+# Everything alice did to FTR-0019 last week, JSON-Lines
+vb audit --format jsonl --actor alice --feature-id FTR-0019 --since 2026-04-10
+
+# Last 5 entries whose details mention "ttl"
+vb audit --contains ttl --limit 5 --tail
+
+# Confirm the audit chain has not been tampered with
+vb audit --verify
+
+# Machine-readable summary for an agent or script
+vb audit --json --since 2026-04-01
+```
+
+**Exit Codes:**
+
+- `0` – Audit log read and rendered successfully (or empty).
+- `1` – Validation error: bad `--format`, unparsable `--since`/`--until`, or `--verify` failure.
+- `6` – Filesystem error reading the audit log.
+
 ### `vb version`
 Print the CLI semantic version (supports JSON output).
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -5,6 +5,24 @@
 - `make test` – run unit tests with coverage (requires 100% coverage).
 - `make package` – build the CLI binary into `dist/`.
 
+## Internal Packages
+
+Contributor-facing APIs in `internal/` are deliberately kept small. The most
+commonly extended packages:
+
+- `internal/feature` – feature spec CRUD, status workflow, body sections.
+- `internal/validator` – schema + workflow + dependency rules.
+- `internal/indexer` – Markdown/JSON/HTML index generators with diff detection.
+- `internal/audit` – the SHA-256 hash-chained audit log. `Logger` appends new
+  entries (used by `internal/lock` and `internal/feature`). `Read` parses the
+  on-disk JSONL file into `[]Entry`, `Filter.Apply` does column filtering,
+  `Render` emits one of six text formats, and `Verify` walks the chain. The
+  `vb audit` command in `cmd/audit.go` is the only consumer today; add new
+  filters by extending `Filter` and new formats by extending the `Format`
+  enum and the `Render` switch.
+- `internal/lock` – TTL-based collaborative locks; emits audit entries on
+  every state transition.
+
 ## GitHub Actions Workflows
 
 This project uses GitHub Actions for automated testing, building, and releasing. The workflow is designed around a `dev` → `main` branching strategy with automatic release creation.

--- a/docs/index.html
+++ b/docs/index.html
@@ -90,7 +90,7 @@
           <div class="flex flex-wrap gap-2.5 justify-center mb-12 stagger">
             <span class="badge badge--primary">Tests &middot; passing</span>
             <span class="badge badge--accent">Coverage &middot; 100%</span>
-            <span class="badge badge--warm">Release &middot; v0.8.1</span>
+            <span class="badge badge--warm">Release &middot; v0.9.0</span>
             <span class="badge badge--muted">SemVer 2.0.0</span>
           </div>
 
@@ -177,6 +177,17 @@
             <h3 class="text-base font-semibold mb-2">Validation + Indexing</h3>
             <p class="text-sm text-muted-foreground leading-relaxed">
               Enforce schema, workflow, and dependency rules with <code class="inline-code">vb validate</code>. Regenerate Markdown, JSON, and HTML indexes via <code class="inline-code">vb index</code>.
+            </p>
+          </div>
+
+          <!-- Tamper-Evident Audit -->
+          <div class="vb-card">
+            <div class="card-icon">
+              <svg class="w-5 h-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            </div>
+            <h3 class="text-base font-semibold mb-2">Tamper-Evident Audit</h3>
+            <p class="text-sm text-muted-foreground leading-relaxed">
+              Inspect the SHA-256 hash-chained audit log with <code class="inline-code">vb audit</code>. Filter on any column, render as human, table, JSON/JSONL, XML, or agent-friendly format, and use <code class="inline-code">--verify</code> to detect tampering.
             </p>
           </div>
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/xeipuuv/gojsonschema v1.2.0
-	golang.org/x/term v0.42.0
+	golang.org/x/term v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -20,5 +20,5 @@ require (
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -31,10 +31,10 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/term v0.42.0 h1:UiKe+zDFmJobeJ5ggPwOshJIVt6/Ft0rcfrXZDLWAWY=
-golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
+golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/audit/reader.go
+++ b/internal/audit/reader.go
@@ -1,0 +1,207 @@
+package audit
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// maxLineBytes caps a single audit line at 1 MiB. The default bufio.Scanner
+// buffer of 64 KiB would refuse longer lines, and details strings can grow.
+const maxLineBytes = 1 << 20
+
+// Read parses an audit JSONL file into a slice of Entry values.
+//
+// Behaviour:
+//   - If the file does not exist, returns an empty slice and nil error (an
+//     un-initialised workspace is not an error condition for reads).
+//   - Blank lines are silently skipped.
+//   - Lines that fail JSON parsing are reported via the returned ParseErrors
+//     slice but do NOT abort the read. Callers may surface the errors as
+//     warnings without losing the entries that did parse.
+func Read(path string) (entries []Entry, parseErrors []ParseError, err error) {
+	// #nosec G304 -- path is constructed from controlled RootDir configuration
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("open audit log: %w", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxLineBytes)
+
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		raw := scanner.Bytes()
+		if len(raw) == 0 {
+			continue
+		}
+		var entry Entry
+		if jerr := json.Unmarshal(raw, &entry); jerr != nil {
+			parseErrors = append(parseErrors, ParseError{Line: lineNum, Err: jerr})
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	if serr := scanner.Err(); serr != nil {
+		return entries, parseErrors, fmt.Errorf("scan audit log: %w", serr)
+	}
+	return entries, parseErrors, nil
+}
+
+// ParseError records a JSON parse failure for a single audit line.
+type ParseError struct {
+	Line int
+	Err  error
+}
+
+// Error implements the error interface.
+func (e ParseError) Error() string {
+	return fmt.Sprintf("line %d: %v", e.Line, e.Err)
+}
+
+// Filter holds optional filter criteria for audit entries. A zero-value Filter
+// matches every entry. Slice fields use OR semantics within the field; the
+// fields themselves combine with AND.
+type Filter struct {
+	Actions    []string
+	Actors     []string
+	FeatureIDs []string
+	Since      *time.Time
+	Until      *time.Time
+	Contains   string // case-insensitive substring match against Details
+	Limit      int    // 0 = no cap
+	Tail       bool   // when Limit > 0, take the last Limit matches instead of the first
+}
+
+// ParseTime accepts RFC3339 timestamps and bare YYYY-MM-DD dates. The empty
+// string yields a nil pointer so callers can pass user input through unchanged.
+func ParseTime(s string) (*time.Time, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return &t, nil
+	}
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return &t, nil
+	}
+	return nil, fmt.Errorf("unrecognised time format %q (expected RFC3339 or YYYY-MM-DD)", s)
+}
+
+// Apply filters the input entries and returns the matching subset. The order
+// of the input slice is preserved, except when Tail is true and Limit > 0,
+// in which case the last Limit matches are returned (still in chronological
+// order).
+func (f Filter) Apply(entries []Entry) []Entry {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	out := make([]Entry, 0, len(entries))
+	for _, e := range entries {
+		if !f.matches(e) {
+			continue
+		}
+		out = append(out, e)
+	}
+
+	if f.Limit > 0 && len(out) > f.Limit {
+		if f.Tail {
+			out = out[len(out)-f.Limit:]
+		} else {
+			out = out[:f.Limit]
+		}
+	}
+	return out
+}
+
+func (f Filter) matches(e Entry) bool {
+	if len(f.Actions) > 0 && !containsString(f.Actions, e.Action) {
+		return false
+	}
+	if len(f.Actors) > 0 && !containsString(f.Actors, e.Actor) {
+		return false
+	}
+	if len(f.FeatureIDs) > 0 && !containsString(f.FeatureIDs, e.FeatureID) {
+		return false
+	}
+	if f.Since != nil || f.Until != nil {
+		ts, err := time.Parse(time.RFC3339, e.Timestamp)
+		if err != nil {
+			// Entries with unparsable timestamps cannot satisfy a time filter.
+			return false
+		}
+		if f.Since != nil && ts.Before(*f.Since) {
+			return false
+		}
+		if f.Until != nil && ts.After(*f.Until) {
+			return false
+		}
+	}
+	if f.Contains != "" {
+		if !strings.Contains(strings.ToLower(e.Details), strings.ToLower(f.Contains)) {
+			return false
+		}
+	}
+	return true
+}
+
+func containsString(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+
+// VerifyError describes a hash-chain integrity failure.
+type VerifyError struct {
+	Index    int    // zero-based index of the offending entry
+	Kind     string // "entry_hash" or "prev_hash"
+	Expected string
+	Got      string
+}
+
+// Error implements the error interface.
+func (e *VerifyError) Error() string {
+	return fmt.Sprintf("audit entry %d: %s mismatch (expected %s, got %s)", e.Index, e.Kind, e.Expected, e.Got)
+}
+
+// Verify walks the hash chain of the given entries and returns nil if the
+// chain is intact. It checks two things per entry:
+//
+//  1. entry_hash matches the recomputed SHA-256 of the entry contents + prev_hash.
+//  2. prev_hash matches the previous entry's entry_hash (or "" for the first entry).
+//
+// The first mismatch wins.
+func Verify(entries []Entry) error {
+	prev := ""
+	for i, e := range entries {
+		if e.PrevHash != prev {
+			return &VerifyError{Index: i, Kind: "prev_hash", Expected: prev, Got: e.PrevHash}
+		}
+		want := computeHash(Entry{
+			Timestamp: e.Timestamp,
+			Action:    e.Action,
+			Actor:     e.Actor,
+			FeatureID: e.FeatureID,
+			Details:   e.Details,
+			PrevHash:  e.PrevHash,
+		})
+		if e.EntryHash != want {
+			return &VerifyError{Index: i, Kind: "entry_hash", Expected: want, Got: e.EntryHash}
+		}
+		prev = e.EntryHash
+	}
+	return nil
+}

--- a/internal/audit/reader_test.go
+++ b/internal/audit/reader_test.go
@@ -1,0 +1,218 @@
+package audit
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeEntries(t *testing.T, path string, actions ...string) []Entry {
+	t.Helper()
+	l, err := NewLogger(path)
+	if err != nil {
+		t.Fatalf("NewLogger failed: %v", err)
+	}
+	for _, a := range actions {
+		if err := l.Log(a, "tester", "FTR-0001", "details for "+a); err != nil {
+			t.Fatalf("Log failed: %v", err)
+		}
+	}
+	entries, _, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	return entries
+}
+
+func TestReadMissingFile(t *testing.T) {
+	entries, parseErrs, err := Read(filepath.Join(t.TempDir(), "nope.jsonl"))
+	if err != nil {
+		t.Fatalf("Read on missing file should not error: %v", err)
+	}
+	if len(entries) != 0 || len(parseErrs) != 0 {
+		t.Fatalf("expected zero entries and zero parse errors, got %d/%d", len(entries), len(parseErrs))
+	}
+}
+
+func TestReadValidAndCorruptLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+
+	// Two valid entries, one corrupt line, one blank line.
+	content := `{"timestamp":"2026-04-16T21:06:59Z","action":"lock","actor":"netors","feature_id":"FTR-1","details":"","prev_hash":"","entry_hash":"h1"}
+not json
+{"timestamp":"2026-04-16T21:07:00Z","action":"unlock","actor":"netors","feature_id":"FTR-1","details":"","prev_hash":"h1","entry_hash":"h2"}
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	entries, parseErrs, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if len(parseErrs) != 1 {
+		t.Fatalf("expected 1 parse error, got %d", len(parseErrs))
+	}
+	if parseErrs[0].Line != 2 {
+		t.Fatalf("expected parse error on line 2, got line %d", parseErrs[0].Line)
+	}
+	if !strings.Contains(parseErrs[0].Error(), "line 2") {
+		t.Fatalf("expected ParseError.Error() to mention line, got %q", parseErrs[0].Error())
+	}
+}
+
+func TestReadOpenError(t *testing.T) {
+	// Pointing Read at a directory triggers a non-IsNotExist open error.
+	dir := t.TempDir()
+	_, _, err := Read(dir)
+	if err == nil {
+		t.Fatalf("expected open error when path is a directory")
+	}
+}
+
+func TestReadScanError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	// A line longer than maxLineBytes forces the scanner to error.
+	long := strings.Repeat("a", maxLineBytes+10)
+	if err := os.WriteFile(path, []byte(long+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := Read(path)
+	if err == nil {
+		t.Fatalf("expected scanner error on overlong line")
+	}
+}
+
+func TestParseTime(t *testing.T) {
+	if tp, err := ParseTime(""); err != nil || tp != nil {
+		t.Fatalf("empty string should yield nil/nil, got %v/%v", tp, err)
+	}
+	if tp, err := ParseTime("2026-04-16"); err != nil || tp == nil {
+		t.Fatalf("YYYY-MM-DD should parse, got err=%v tp=%v", err, tp)
+	}
+	if tp, err := ParseTime("2026-04-16T12:00:00Z"); err != nil || tp == nil {
+		t.Fatalf("RFC3339 should parse, got err=%v tp=%v", err, tp)
+	}
+	if _, err := ParseTime("not a date"); err == nil {
+		t.Fatalf("garbage should fail to parse")
+	}
+}
+
+func TestFilterEmptyInput(t *testing.T) {
+	if got := (Filter{}).Apply(nil); got != nil {
+		t.Fatalf("filtering nil should yield nil, got %v", got)
+	}
+}
+
+func TestFilterByEveryDimension(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	entries := writeEntries(t, path, "lock", "unlock", "move", "delete", "create")
+	// Re-hydrate with different actors/feature_ids/details by appending raw entries.
+	// Easier: just craft entries directly.
+	entries = []Entry{
+		{Timestamp: "2026-04-16T10:00:00Z", Action: "lock", Actor: "alice", FeatureID: "FTR-1", Details: "owner=alice ttl=1"},
+		{Timestamp: "2026-04-17T10:00:00Z", Action: "unlock", Actor: "bob", FeatureID: "FTR-1", Details: "owner=bob"},
+		{Timestamp: "2026-04-18T10:00:00Z", Action: "move", Actor: "alice", FeatureID: "FTR-2", Details: "from=backlog to=in-progress"},
+		{Timestamp: "2026-04-19T10:00:00Z", Action: "create", Actor: "carol", FeatureID: "FTR-3", Details: ""},
+		{Timestamp: "bad-timestamp", Action: "delete", Actor: "alice", FeatureID: "FTR-4", Details: ""},
+	}
+
+	tests := []struct {
+		name   string
+		filter Filter
+		want   int
+	}{
+		{"all", Filter{}, 5},
+		{"action=lock", Filter{Actions: []string{"lock"}}, 1},
+		{"action=lock|unlock", Filter{Actions: []string{"lock", "unlock"}}, 2},
+		{"actor=alice", Filter{Actors: []string{"alice"}}, 3},
+		{"feature_id=FTR-1", Filter{FeatureIDs: []string{"FTR-1"}}, 2},
+		{"contains owner", Filter{Contains: "OWNER"}, 2},
+		{"contains miss", Filter{Contains: "nonexistent"}, 0},
+		{"since 2026-04-18", Filter{Since: mustTime(t, "2026-04-18")}, 2}, // entries on/after 04-18 with valid TS
+		{"until 2026-04-16", Filter{Until: mustTime(t, "2026-04-16T23:59:59Z")}, 1},
+		{"since+until window", Filter{Since: mustTime(t, "2026-04-17"), Until: mustTime(t, "2026-04-18T23:59:59Z")}, 2},
+		{"limit head", Filter{Limit: 2}, 2},
+		{"limit tail", Filter{Limit: 2, Tail: true}, 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.filter.Apply(entries)
+			if len(got) != tc.want {
+				t.Fatalf("want %d, got %d (%v)", tc.want, len(got), got)
+			}
+		})
+	}
+
+	// Tail returns the LAST N, head returns the FIRST N.
+	head := Filter{Limit: 2}.Apply(entries)
+	tail := Filter{Limit: 2, Tail: true}.Apply(entries)
+	if head[0].Action != "lock" || head[1].Action != "unlock" {
+		t.Fatalf("head wrong: %v", head)
+	}
+	if tail[0].Action != "create" || tail[1].Action != "delete" {
+		t.Fatalf("tail wrong: %v", tail)
+	}
+}
+
+func mustTime(t *testing.T, s string) *time.Time {
+	t.Helper()
+	tp, err := ParseTime(s)
+	if err != nil {
+		t.Fatalf("ParseTime(%q): %v", s, err)
+	}
+	return tp
+}
+
+func TestVerifyClean(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	entries := writeEntries(t, path, "create", "move", "delete")
+	if err := Verify(entries); err != nil {
+		t.Fatalf("Verify on intact chain failed: %v", err)
+	}
+}
+
+func TestVerifyEntryHashMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	entries := writeEntries(t, path, "create", "move")
+	entries[1].EntryHash = "tampered"
+	err := Verify(entries)
+	if err == nil {
+		t.Fatalf("expected error on tampered entry_hash")
+	}
+	var ve *VerifyError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected *VerifyError, got %T", err)
+	}
+	if ve.Index != 1 || ve.Kind != "entry_hash" {
+		t.Fatalf("unexpected VerifyError: %+v", ve)
+	}
+	if !strings.Contains(ve.Error(), "entry_hash mismatch") {
+		t.Fatalf("Error() should describe the mismatch, got %q", ve.Error())
+	}
+}
+
+func TestVerifyPrevHashMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	entries := writeEntries(t, path, "create", "move")
+	entries[1].PrevHash = "wrong"
+	err := Verify(entries)
+	var ve *VerifyError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected *VerifyError, got %v", err)
+	}
+	if ve.Kind != "prev_hash" {
+		t.Fatalf("expected prev_hash mismatch, got %s", ve.Kind)
+	}
+}

--- a/internal/audit/render.go
+++ b/internal/audit/render.go
@@ -1,0 +1,213 @@
+package audit
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+)
+
+// Format identifies a renderer for audit entries.
+type Format string
+
+// Supported render formats.
+const (
+	FormatHuman Format = "human"
+	FormatTable Format = "table"
+	FormatJSONL Format = "jsonl"
+	FormatJSON  Format = "json"
+	FormatXML   Format = "xml"
+	FormatAgent Format = "agent"
+)
+
+// Formats lists every supported format value, for help text and validation.
+var Formats = []Format{FormatHuman, FormatTable, FormatJSONL, FormatJSON, FormatXML, FormatAgent}
+
+// ParseFormat returns the canonical Format for s or an error listing the valid options.
+func ParseFormat(s string) (Format, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "human":
+		return FormatHuman, nil
+	case "table":
+		return FormatTable, nil
+	case "jsonl":
+		return FormatJSONL, nil
+	case "json":
+		return FormatJSON, nil
+	case "xml":
+		return FormatXML, nil
+	case "agent":
+		return FormatAgent, nil
+	}
+	names := make([]string, len(Formats))
+	for i, f := range Formats {
+		names[i] = string(f)
+	}
+	return "", fmt.Errorf("unknown format %q (valid: %s)", s, strings.Join(names, ", "))
+}
+
+// RenderOptions controls renderer behaviour.
+type RenderOptions struct {
+	// IncludeHashes, when true, makes the human/table/agent renderers include
+	// the truncated prev_hash and entry_hash. JSON/JSONL/XML always include them.
+	IncludeHashes bool
+}
+
+// Render dispatches to the appropriate per-format renderer.
+func Render(entries []Entry, format Format, opts RenderOptions) (string, error) {
+	switch format {
+	case FormatJSONL:
+		return renderJSONL(entries)
+	case FormatJSON:
+		return renderJSON(entries)
+	case FormatXML:
+		return renderXML(entries)
+	case FormatTable:
+		return renderTable(entries, opts), nil
+	case FormatAgent:
+		return renderAgent(entries, opts), nil
+	case FormatHuman, "":
+		return renderHuman(entries, opts), nil
+	}
+	return "", fmt.Errorf("unsupported format %q", format)
+}
+
+func renderJSONL(entries []Entry) (string, error) {
+	var b strings.Builder
+	for _, e := range entries {
+		data, err := json.Marshal(e)
+		if err != nil {
+			return "", fmt.Errorf("marshal entry: %w", err)
+		}
+		b.Write(data)
+		b.WriteByte('\n')
+	}
+	return b.String(), nil
+}
+
+func renderJSON(entries []Entry) (string, error) {
+	out := map[string]interface{}{
+		"count":   len(entries),
+		"entries": entries,
+	}
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal json: %w", err)
+	}
+	return string(data) + "\n", nil
+}
+
+// auditXML is the root element wrapper for XML output.
+type auditXML struct {
+	XMLName xml.Name `xml:"audit"`
+	Count   int      `xml:"count,attr"`
+	Entries []Entry  `xml:"entry"`
+}
+
+func renderXML(entries []Entry) (string, error) {
+	wrap := auditXML{Count: len(entries), Entries: entries}
+	data, err := xml.MarshalIndent(wrap, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal xml: %w", err)
+	}
+	return xml.Header + string(data) + "\n", nil
+}
+
+func renderTable(entries []Entry, opts RenderOptions) string {
+	var b strings.Builder
+	w := tabwriter.NewWriter(&b, 0, 4, 2, ' ', 0)
+	header := "TIMESTAMP\tACTION\tACTOR\tFEATURE_ID\tDETAILS"
+	if opts.IncludeHashes {
+		header += "\tPREV\tHASH"
+	}
+	fmt.Fprintln(w, header)
+	for _, e := range entries {
+		row := fmt.Sprintf("%s\t%s\t%s\t%s\t%s",
+			formatTimestamp(e.Timestamp),
+			emptyDash(e.Action),
+			emptyDash(e.Actor),
+			emptyDash(e.FeatureID),
+			emptyDash(e.Details),
+		)
+		if opts.IncludeHashes {
+			row += "\t" + shortHash(e.PrevHash) + "\t" + shortHash(e.EntryHash)
+		}
+		fmt.Fprintln(w, row)
+	}
+	_ = w.Flush()
+	return b.String()
+}
+
+func renderHuman(entries []Entry, opts RenderOptions) string {
+	if len(entries) == 0 {
+		return "No audit entries match the given filters.\n"
+	}
+	var b strings.Builder
+	for _, e := range entries {
+		fmt.Fprintf(&b, "%s  %-10s  %-12s  %-20s  %s",
+			formatTimestamp(e.Timestamp),
+			emptyDash(e.Action),
+			emptyDash(e.Actor),
+			emptyDash(e.FeatureID),
+			emptyDash(e.Details),
+		)
+		if opts.IncludeHashes {
+			fmt.Fprintf(&b, "  prev=%s hash=%s", shortHash(e.PrevHash), shortHash(e.EntryHash))
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func renderAgent(entries []Entry, opts RenderOptions) string {
+	if len(entries) == 0 {
+		return "count: 0\nentries: []\n"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "count: %d\n", len(entries))
+	for i, e := range entries {
+		fmt.Fprintf(&b, "\n--- entry %d ---\n", i+1)
+		fmt.Fprintf(&b, "timestamp: %s\n", e.Timestamp)
+		fmt.Fprintf(&b, "action: %s\n", e.Action)
+		fmt.Fprintf(&b, "actor: %s\n", e.Actor)
+		if e.FeatureID != "" {
+			fmt.Fprintf(&b, "feature_id: %s\n", e.FeatureID)
+		}
+		if e.Details != "" {
+			fmt.Fprintf(&b, "details: %s\n", e.Details)
+		}
+		if opts.IncludeHashes {
+			fmt.Fprintf(&b, "prev_hash: %s\n", e.PrevHash)
+			fmt.Fprintf(&b, "entry_hash: %s\n", e.EntryHash)
+		}
+	}
+	return b.String()
+}
+
+// formatTimestamp renders RFC3339 timestamps as "2026-04-16 21:06:59" for
+// human-readable formats. Unparsable timestamps pass through unchanged so
+// debugging odd entries is still possible.
+func formatTimestamp(ts string) string {
+	if len(ts) >= 19 && ts[10] == 'T' {
+		return ts[:10] + " " + ts[11:19]
+	}
+	return ts
+}
+
+func emptyDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func shortHash(h string) string {
+	if len(h) == 0 {
+		return "-"
+	}
+	if len(h) <= 8 {
+		return h
+	}
+	return h[:8]
+}

--- a/internal/audit/render_test.go
+++ b/internal/audit/render_test.go
@@ -1,0 +1,235 @@
+package audit
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"strings"
+	"testing"
+)
+
+func sampleEntries() []Entry {
+	return []Entry{
+		{
+			Timestamp: "2026-04-16T21:06:59Z",
+			Action:    "lock",
+			Actor:     "netors",
+			FeatureID: "op-move-FTR-0019",
+			Details:   "owner=vb-cli-op ttl=1",
+			PrevHash:  "",
+			EntryHash: "96bd69a73fdc5a51d2758e869b6ea7c60c03f32ef274f4008eb8a60e3aaafc97",
+		},
+		{
+			Timestamp: "2026-04-16T21:07:05Z",
+			Action:    "unlock",
+			Actor:     "netors",
+			FeatureID: "op-move-FTR-0019",
+			Details:   "",
+			PrevHash:  "96bd69a73fdc5a51d2758e869b6ea7c60c03f32ef274f4008eb8a60e3aaafc97",
+			EntryHash: "deadbeefcafefeed1234567890abcdefdeadbeefcafefeed1234567890abcdef",
+		},
+	}
+}
+
+func TestParseFormat(t *testing.T) {
+	cases := map[string]Format{
+		"":       FormatHuman,
+		"human":  FormatHuman,
+		"HUMAN":  FormatHuman,
+		" table": FormatTable,
+		"jsonl":  FormatJSONL,
+		"json":   FormatJSON,
+		"xml":    FormatXML,
+		"agent":  FormatAgent,
+	}
+	for input, want := range cases {
+		got, err := ParseFormat(input)
+		if err != nil {
+			t.Fatalf("ParseFormat(%q) errored: %v", input, err)
+		}
+		if got != want {
+			t.Fatalf("ParseFormat(%q) = %q, want %q", input, got, want)
+		}
+	}
+
+	if _, err := ParseFormat("yaml"); err == nil {
+		t.Fatalf("expected error for unknown format")
+	}
+}
+
+func TestRenderJSONL(t *testing.T) {
+	out, err := Render(sampleEntries(), FormatJSONL, RenderOptions{})
+	if err != nil {
+		t.Fatalf("Render jsonl failed: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 jsonl lines, got %d", len(lines))
+	}
+	var e Entry
+	if err := json.Unmarshal([]byte(lines[0]), &e); err != nil {
+		t.Fatalf("first line not valid JSON: %v", err)
+	}
+	if e.Action != "lock" {
+		t.Fatalf("expected action=lock, got %q", e.Action)
+	}
+}
+
+func TestRenderJSON(t *testing.T) {
+	out, err := Render(sampleEntries(), FormatJSON, RenderOptions{})
+	if err != nil {
+		t.Fatalf("Render json failed: %v", err)
+	}
+	var payload struct {
+		Count   int     `json:"count"`
+		Entries []Entry `json:"entries"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("output not valid JSON: %v\noutput:\n%s", err, out)
+	}
+	if payload.Count != 2 || len(payload.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got count=%d entries=%d", payload.Count, len(payload.Entries))
+	}
+}
+
+func TestRenderXML(t *testing.T) {
+	out, err := Render(sampleEntries(), FormatXML, RenderOptions{})
+	if err != nil {
+		t.Fatalf("Render xml failed: %v", err)
+	}
+	if !strings.HasPrefix(out, xml.Header) {
+		t.Fatalf("XML output missing header")
+	}
+	var wrap auditXML
+	body := strings.TrimPrefix(out, xml.Header)
+	if err := xml.Unmarshal([]byte(body), &wrap); err != nil {
+		t.Fatalf("XML output failed to unmarshal: %v\n%s", err, out)
+	}
+	if wrap.Count != 2 || len(wrap.Entries) != 2 {
+		t.Fatalf("wrong XML count: %+v", wrap)
+	}
+}
+
+func TestRenderTable(t *testing.T) {
+	out, err := Render(sampleEntries(), FormatTable, RenderOptions{})
+	if err != nil {
+		t.Fatalf("Render table failed: %v", err)
+	}
+	if !strings.Contains(out, "TIMESTAMP") {
+		t.Fatalf("table missing header: %s", out)
+	}
+	if !strings.Contains(out, "lock") || !strings.Contains(out, "unlock") {
+		t.Fatalf("table missing rows: %s", out)
+	}
+	if strings.Contains(out, "PREV") {
+		t.Fatalf("table should not include hash columns by default")
+	}
+
+	// With hashes.
+	out, err = Render(sampleEntries(), FormatTable, RenderOptions{IncludeHashes: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "PREV") || !strings.Contains(out, "HASH") {
+		t.Fatalf("table with hashes missing columns: %s", out)
+	}
+	if !strings.Contains(out, "96bd69a7") {
+		t.Fatalf("table should include truncated hash: %s", out)
+	}
+}
+
+func TestRenderHuman(t *testing.T) {
+	out, err := Render(sampleEntries(), FormatHuman, RenderOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "2026-04-16 21:06:59") {
+		t.Fatalf("expected reformatted timestamp, got: %s", out)
+	}
+	if !strings.Contains(out, "owner=vb-cli-op") {
+		t.Fatalf("human output missing details: %s", out)
+	}
+	if strings.Contains(out, "prev=") {
+		t.Fatalf("default human output should hide hashes")
+	}
+
+	// With hashes.
+	out, err = Render(sampleEntries(), FormatHuman, RenderOptions{IncludeHashes: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "prev=-") || !strings.Contains(out, "hash=96bd69a7") {
+		t.Fatalf("verbose human missing hashes: %s", out)
+	}
+
+	// Empty.
+	out, err = Render(nil, FormatHuman, RenderOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "No audit entries") {
+		t.Fatalf("expected empty-state message, got %q", out)
+	}
+}
+
+func TestRenderAgent(t *testing.T) {
+	// Empty
+	out, err := Render(nil, FormatAgent, RenderOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "count: 0") {
+		t.Fatalf("empty agent output wrong: %s", out)
+	}
+
+	// Default (no hashes)
+	out, err = Render(sampleEntries(), FormatAgent, RenderOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "count: 2") || !strings.Contains(out, "--- entry 1 ---") {
+		t.Fatalf("agent output missing structure: %s", out)
+	}
+	if strings.Contains(out, "prev_hash:") {
+		t.Fatalf("default agent should hide hashes: %s", out)
+	}
+
+	// With hashes
+	out, err = Render(sampleEntries(), FormatAgent, RenderOptions{IncludeHashes: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "prev_hash:") || !strings.Contains(out, "entry_hash:") {
+		t.Fatalf("verbose agent missing hashes: %s", out)
+	}
+
+	// Entry with empty optional fields should omit those keys.
+	minimal := []Entry{{Timestamp: "2026-04-16T21:06:59Z", Action: "lock", Actor: "system"}}
+	out, err = Render(minimal, FormatAgent, RenderOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "feature_id:") || strings.Contains(out, "details:") {
+		t.Fatalf("agent should omit empty optionals: %s", out)
+	}
+}
+
+func TestRenderUnknownFormat(t *testing.T) {
+	if _, err := Render(sampleEntries(), Format("nope"), RenderOptions{}); err == nil {
+		t.Fatalf("expected error for unsupported format")
+	}
+}
+
+func TestFormatTimestampPassThrough(t *testing.T) {
+	if got := formatTimestamp("garbage"); got != "garbage" {
+		t.Fatalf("expected pass-through for non-RFC3339 timestamp, got %q", got)
+	}
+}
+
+func TestShortHashEdgeCases(t *testing.T) {
+	if got := shortHash(""); got != "-" {
+		t.Fatalf("empty hash should render as dash, got %q", got)
+	}
+	if got := shortHash("abc"); got != "abc" {
+		t.Fatalf("short hash should pass through, got %q", got)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Current defines the CLI semantic version following https://semver.org/.
-const Current = "v0.8.2"
+const Current = "v0.9.0"
 
 // Parsed represents a parsed semantic version.
 type Parsed struct {


### PR DESCRIPTION
Introduces a tamper-evident audit log inspector with filters on every column (action, actor, feature_id, since/until, contains, limit/tail), six output formats (human, table, jsonl, json, xml, agent), and a --verify flag that walks the SHA-256 hash chain.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Test coverage remains at 100%
- [ ] Manual testing completed

## Security

- [ ] Security scan passes (`make scan`)
- [ ] No new security vulnerabilities introduced
- [ ] File permissions are appropriate
- [ ] No hardcoded secrets or credentials

## Documentation

- [ ] README.md updated (if needed)
- [ ] CLI.md updated (if command behavior changed)
- [ ] DEVELOPMENT.md updated (if build process changed)
- [ ] CHANGELOG.md updated
- [ ] Code comments added for complex logic

## Version Bump

- [ ] Version bumped in `internal/version/version.go`
- [ ] Changelog entry added
- [ ] Version bump type: [ ] Major [ ] Minor [ ] Patch

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Code is properly commented
- [ ] No debug code or console logs left
- [ ] All `make` targets pass locally
- [ ] Pre-commit hooks pass

## Additional Notes

Any additional information, context, or screenshots that would help reviewers understand the changes.
